### PR TITLE
Add Datadog middleware package

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "build": "yarn install && yarn build"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Third-party middleware for Hono",
   "workspaces": {
     "packages": [
-      "packages/*"
+      "packages/*",
+      "packages/datadog"
     ]
   },
   "scripts": {

--- a/packages/datadog/README.md
+++ b/packages/datadog/README.md
@@ -1,0 +1,49 @@
+# @hono/datadog
+
+Datadog middleware for Hono.
+
+## Usage
+
+To use the Datadog middleware, you need to install the `dd-trace` package and then use the middleware in your Hono application.
+
+```sh
+yarn add dd-trace
+```
+
+```ts
+import { Hono } from 'hono'
+import { datadogMiddleware } from '@hono/datadog'
+
+const app = new Hono()
+
+app.use('*', datadogMiddleware())
+
+app.get('/', (c) => c.text('Hello, Datadog!'))
+
+app.fire()
+```
+
+## Example
+
+Here is an example of how to use the Datadog middleware with Hono:
+
+```ts
+import { Hono } from 'hono'
+import { datadogMiddleware } from '@hono/datadog'
+
+const app = new Hono()
+
+app.use('*', datadogMiddleware())
+
+app.get('/', (c) => c.text('Hello, Datadog!'))
+
+app.fire()
+```
+
+## Author
+
+Hono Team
+
+## License
+
+MIT

--- a/packages/datadog/package.json
+++ b/packages/datadog/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@hono/datadog",
+  "version": "0.1.0",
+  "description": "Datadog middleware for Hono",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup ./src/index.ts",
+    "prepack": "yarn build",
+    "publint": "attw --pack && publint",
+    "typecheck": "tsc -b tsconfig.json",
+    "test": "vitest"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/honojs/middleware.git",
+    "directory": "packages/datadog"
+  },
+  "homepage": "https://github.com/honojs/middleware",
+  "peerDependencies": {
+    "dd-trace": "^1.0.0",
+    "hono": ">=3.9.0"
+  },
+  "devDependencies": {
+    "@arethetypeswrong/cli": "^0.17.4",
+    "publint": "^0.3.9",
+    "tsup": "^8.4.0",
+    "typescript": "^5.8.2",
+    "vitest": "^3.0.8"
+  }
+}

--- a/packages/datadog/src/index.test.ts
+++ b/packages/datadog/src/index.test.ts
@@ -1,0 +1,44 @@
+import { Hono } from 'hono'
+import { datadogMiddleware } from './index'
+
+describe('Datadog Middleware', () => {
+  const app = new Hono()
+
+  app.use('*', datadogMiddleware())
+
+  app.get('/hello', (c) => c.text('Hello, world!'))
+  app.post('/data', (c) => c.json({ success: true }))
+
+  it('Should return 200 response for GET /hello', async () => {
+    const req = new Request('http://localhost/hello')
+    const res = await app.request(req)
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('Hello, world!')
+  })
+
+  it('Should return 200 response for POST /data', async () => {
+    const req = new Request('http://localhost/data', {
+      method: 'POST',
+      body: JSON.stringify({ key: 'value' }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+    const res = await app.request(req)
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true })
+  })
+
+  it('Should handle errors correctly', async () => {
+    app.get('/error', () => {
+      throw new Error('Test error')
+    })
+
+    const req = new Request('http://localhost/error')
+    const res = await app.request(req)
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(500)
+  })
+})

--- a/packages/datadog/src/index.ts
+++ b/packages/datadog/src/index.ts
@@ -1,0 +1,24 @@
+import tracer from 'dd-trace'
+
+tracer.init()
+
+export const datadogMiddleware = () => {
+  return async (c, next) => {
+    const span = tracer.startSpan('hono.request', {
+      resource: c.req.url,
+      service: 'hono',
+      type: 'web',
+    })
+
+    try {
+      await next()
+    } catch (error) {
+      span.setTag('error', true)
+      span.setTag('error.message', error.message)
+      span.setTag('error.stack', error.stack)
+      throw error
+    } finally {
+      span.finish()
+    }
+  }
+}

--- a/packages/datadog/tsconfig.build.json
+++ b/packages/datadog/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/datadog/tsconfig.json
+++ b/packages/datadog/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"],
+  "references": [
+    {
+      "path": "./tsconfig.build.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/datadog/tsconfig.spec.json
+++ b/packages/datadog/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc/packages/datadog"
+  },
+  "include": ["src/**/*.test.ts", "vitest.config.ts"]
+}

--- a/packages/datadog/vitest.config.ts
+++ b/packages/datadog/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/tsup.config.bundled_05uqpttfvroq.mjs
+++ b/tsup.config.bundled_05uqpttfvroq.mjs
@@ -1,0 +1,14 @@
+// ../../tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig((overrideOptions) => ({
+  ...overrideOptions,
+  clean: true,
+  dts: true,
+  format: ["cjs", "esm"],
+  outDir: "dist",
+  tsconfig: "tsconfig.tsup.json"
+}));
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vdHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL3dvcmtzcGFjZXMvbWlkZGxld2FyZS90c3VwLmNvbmZpZy50c1wiO2NvbnN0IF9faW5qZWN0ZWRfZGlybmFtZV9fID0gXCIvd29ya3NwYWNlcy9taWRkbGV3YXJlXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy93b3Jrc3BhY2VzL21pZGRsZXdhcmUvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKG92ZXJyaWRlT3B0aW9ucykgPT4gKHtcbiAgLi4ub3ZlcnJpZGVPcHRpb25zLFxuICBjbGVhbjogdHJ1ZSxcbiAgZHRzOiB0cnVlLFxuICBmb3JtYXQ6IFsnY2pzJywgJ2VzbSddLFxuICBvdXREaXI6ICdkaXN0JyxcbiAgdHNjb25maWc6ICd0c2NvbmZpZy50c3VwLmpzb24nLFxufSkpXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWdOLFNBQVMsb0JBQW9CO0FBRTdPLElBQU8sc0JBQVEsYUFBYSxDQUFDLHFCQUFxQjtBQUFBLEVBQ2hELEdBQUc7QUFBQSxFQUNILE9BQU87QUFBQSxFQUNQLEtBQUs7QUFBQSxFQUNMLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxFQUNyQixRQUFRO0FBQUEsRUFDUixVQUFVO0FBQ1osRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K

--- a/tsup.config.bundled_2t8rodcfzr1.mjs
+++ b/tsup.config.bundled_2t8rodcfzr1.mjs
@@ -1,0 +1,14 @@
+// ../../tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig((overrideOptions) => ({
+  ...overrideOptions,
+  clean: true,
+  dts: true,
+  format: ["cjs", "esm"],
+  outDir: "dist",
+  tsconfig: "tsconfig.tsup.json"
+}));
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vdHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL3dvcmtzcGFjZXMvbWlkZGxld2FyZS90c3VwLmNvbmZpZy50c1wiO2NvbnN0IF9faW5qZWN0ZWRfZGlybmFtZV9fID0gXCIvd29ya3NwYWNlcy9taWRkbGV3YXJlXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy93b3Jrc3BhY2VzL21pZGRsZXdhcmUvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKG92ZXJyaWRlT3B0aW9ucykgPT4gKHtcbiAgLi4ub3ZlcnJpZGVPcHRpb25zLFxuICBjbGVhbjogdHJ1ZSxcbiAgZHRzOiB0cnVlLFxuICBmb3JtYXQ6IFsnY2pzJywgJ2VzbSddLFxuICBvdXREaXI6ICdkaXN0JyxcbiAgdHNjb25maWc6ICd0c2NvbmZpZy50c3VwLmpzb24nLFxufSkpXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWdOLFNBQVMsb0JBQW9CO0FBRTdPLElBQU8sc0JBQVEsYUFBYSxDQUFDLHFCQUFxQjtBQUFBLEVBQ2hELEdBQUc7QUFBQSxFQUNILE9BQU87QUFBQSxFQUNQLEtBQUs7QUFBQSxFQUNMLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxFQUNyQixRQUFRO0FBQUEsRUFDUixVQUFVO0FBQ1osRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K

--- a/tsup.config.bundled_5c73b3fkvqd.mjs
+++ b/tsup.config.bundled_5c73b3fkvqd.mjs
@@ -1,0 +1,14 @@
+// ../../tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig((overrideOptions) => ({
+  ...overrideOptions,
+  clean: true,
+  dts: true,
+  format: ["cjs", "esm"],
+  outDir: "dist",
+  tsconfig: "tsconfig.tsup.json"
+}));
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vdHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL3dvcmtzcGFjZXMvbWlkZGxld2FyZS90c3VwLmNvbmZpZy50c1wiO2NvbnN0IF9faW5qZWN0ZWRfZGlybmFtZV9fID0gXCIvd29ya3NwYWNlcy9taWRkbGV3YXJlXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy93b3Jrc3BhY2VzL21pZGRsZXdhcmUvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKG92ZXJyaWRlT3B0aW9ucykgPT4gKHtcbiAgLi4ub3ZlcnJpZGVPcHRpb25zLFxuICBjbGVhbjogdHJ1ZSxcbiAgZHRzOiB0cnVlLFxuICBmb3JtYXQ6IFsnY2pzJywgJ2VzbSddLFxuICBvdXREaXI6ICdkaXN0JyxcbiAgdHNjb25maWc6ICd0c2NvbmZpZy50c3VwLmpzb24nLFxufSkpXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWdOLFNBQVMsb0JBQW9CO0FBRTdPLElBQU8sc0JBQVEsYUFBYSxDQUFDLHFCQUFxQjtBQUFBLEVBQ2hELEdBQUc7QUFBQSxFQUNILE9BQU87QUFBQSxFQUNQLEtBQUs7QUFBQSxFQUNMLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxFQUNyQixRQUFRO0FBQUEsRUFDUixVQUFVO0FBQ1osRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K

--- a/tsup.config.bundled_6wc85fund3t.mjs
+++ b/tsup.config.bundled_6wc85fund3t.mjs
@@ -1,0 +1,14 @@
+// ../../tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig((overrideOptions) => ({
+  ...overrideOptions,
+  clean: true,
+  dts: true,
+  format: ["cjs", "esm"],
+  outDir: "dist",
+  tsconfig: "tsconfig.tsup.json"
+}));
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vdHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL3dvcmtzcGFjZXMvbWlkZGxld2FyZS90c3VwLmNvbmZpZy50c1wiO2NvbnN0IF9faW5qZWN0ZWRfZGlybmFtZV9fID0gXCIvd29ya3NwYWNlcy9taWRkbGV3YXJlXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy93b3Jrc3BhY2VzL21pZGRsZXdhcmUvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKG92ZXJyaWRlT3B0aW9ucykgPT4gKHtcbiAgLi4ub3ZlcnJpZGVPcHRpb25zLFxuICBjbGVhbjogdHJ1ZSxcbiAgZHRzOiB0cnVlLFxuICBmb3JtYXQ6IFsnY2pzJywgJ2VzbSddLFxuICBvdXREaXI6ICdkaXN0JyxcbiAgdHNjb25maWc6ICd0c2NvbmZpZy50c3VwLmpzb24nLFxufSkpXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWdOLFNBQVMsb0JBQW9CO0FBRTdPLElBQU8sc0JBQVEsYUFBYSxDQUFDLHFCQUFxQjtBQUFBLEVBQ2hELEdBQUc7QUFBQSxFQUNILE9BQU87QUFBQSxFQUNQLEtBQUs7QUFBQSxFQUNMLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxFQUNyQixRQUFRO0FBQUEsRUFDUixVQUFVO0FBQ1osRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K

--- a/tsup.config.bundled_8ikrypt5d5r.mjs
+++ b/tsup.config.bundled_8ikrypt5d5r.mjs
@@ -1,0 +1,14 @@
+// ../../tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig((overrideOptions) => ({
+  ...overrideOptions,
+  clean: true,
+  dts: true,
+  format: ["cjs", "esm"],
+  outDir: "dist",
+  tsconfig: "tsconfig.tsup.json"
+}));
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vdHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL3dvcmtzcGFjZXMvbWlkZGxld2FyZS90c3VwLmNvbmZpZy50c1wiO2NvbnN0IF9faW5qZWN0ZWRfZGlybmFtZV9fID0gXCIvd29ya3NwYWNlcy9taWRkbGV3YXJlXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy93b3Jrc3BhY2VzL21pZGRsZXdhcmUvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKG92ZXJyaWRlT3B0aW9ucykgPT4gKHtcbiAgLi4ub3ZlcnJpZGVPcHRpb25zLFxuICBjbGVhbjogdHJ1ZSxcbiAgZHRzOiB0cnVlLFxuICBmb3JtYXQ6IFsnY2pzJywgJ2VzbSddLFxuICBvdXREaXI6ICdkaXN0JyxcbiAgdHNjb25maWc6ICd0c2NvbmZpZy50c3VwLmpzb24nLFxufSkpXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWdOLFNBQVMsb0JBQW9CO0FBRTdPLElBQU8sc0JBQVEsYUFBYSxDQUFDLHFCQUFxQjtBQUFBLEVBQ2hELEdBQUc7QUFBQSxFQUNILE9BQU87QUFBQSxFQUNQLEtBQUs7QUFBQSxFQUNMLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxFQUNyQixRQUFRO0FBQUEsRUFDUixVQUFVO0FBQ1osRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K

--- a/tsup.config.bundled_adxw29rm25.mjs
+++ b/tsup.config.bundled_adxw29rm25.mjs
@@ -1,0 +1,14 @@
+// ../../tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig((overrideOptions) => ({
+  ...overrideOptions,
+  clean: true,
+  dts: true,
+  format: ["cjs", "esm"],
+  outDir: "dist",
+  tsconfig: "tsconfig.tsup.json"
+}));
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vdHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL3dvcmtzcGFjZXMvbWlkZGxld2FyZS90c3VwLmNvbmZpZy50c1wiO2NvbnN0IF9faW5qZWN0ZWRfZGlybmFtZV9fID0gXCIvd29ya3NwYWNlcy9taWRkbGV3YXJlXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy93b3Jrc3BhY2VzL21pZGRsZXdhcmUvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKG92ZXJyaWRlT3B0aW9ucykgPT4gKHtcbiAgLi4ub3ZlcnJpZGVPcHRpb25zLFxuICBjbGVhbjogdHJ1ZSxcbiAgZHRzOiB0cnVlLFxuICBmb3JtYXQ6IFsnY2pzJywgJ2VzbSddLFxuICBvdXREaXI6ICdkaXN0JyxcbiAgdHNjb25maWc6ICd0c2NvbmZpZy50c3VwLmpzb24nLFxufSkpXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWdOLFNBQVMsb0JBQW9CO0FBRTdPLElBQU8sc0JBQVEsYUFBYSxDQUFDLHFCQUFxQjtBQUFBLEVBQ2hELEdBQUc7QUFBQSxFQUNILE9BQU87QUFBQSxFQUNQLEtBQUs7QUFBQSxFQUNMLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxFQUNyQixRQUFRO0FBQUEsRUFDUixVQUFVO0FBQ1osRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K

--- a/tsup.config.bundled_ci61wy8wse4.mjs
+++ b/tsup.config.bundled_ci61wy8wse4.mjs
@@ -1,0 +1,14 @@
+// ../../tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig((overrideOptions) => ({
+  ...overrideOptions,
+  clean: true,
+  dts: true,
+  format: ["cjs", "esm"],
+  outDir: "dist",
+  tsconfig: "tsconfig.tsup.json"
+}));
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vdHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL3dvcmtzcGFjZXMvbWlkZGxld2FyZS90c3VwLmNvbmZpZy50c1wiO2NvbnN0IF9faW5qZWN0ZWRfZGlybmFtZV9fID0gXCIvd29ya3NwYWNlcy9taWRkbGV3YXJlXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy93b3Jrc3BhY2VzL21pZGRsZXdhcmUvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKG92ZXJyaWRlT3B0aW9ucykgPT4gKHtcbiAgLi4ub3ZlcnJpZGVPcHRpb25zLFxuICBjbGVhbjogdHJ1ZSxcbiAgZHRzOiB0cnVlLFxuICBmb3JtYXQ6IFsnY2pzJywgJ2VzbSddLFxuICBvdXREaXI6ICdkaXN0JyxcbiAgdHNjb25maWc6ICd0c2NvbmZpZy50c3VwLmpzb24nLFxufSkpXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWdOLFNBQVMsb0JBQW9CO0FBRTdPLElBQU8sc0JBQVEsYUFBYSxDQUFDLHFCQUFxQjtBQUFBLEVBQ2hELEdBQUc7QUFBQSxFQUNILE9BQU87QUFBQSxFQUNQLEtBQUs7QUFBQSxFQUNMLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxFQUNyQixRQUFRO0FBQUEsRUFDUixVQUFVO0FBQ1osRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K

--- a/tsup.config.bundled_iau7z7wbt8.mjs
+++ b/tsup.config.bundled_iau7z7wbt8.mjs
@@ -1,0 +1,14 @@
+// ../../tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig((overrideOptions) => ({
+  ...overrideOptions,
+  clean: true,
+  dts: true,
+  format: ["cjs", "esm"],
+  outDir: "dist",
+  tsconfig: "tsconfig.tsup.json"
+}));
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vdHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL3dvcmtzcGFjZXMvbWlkZGxld2FyZS90c3VwLmNvbmZpZy50c1wiO2NvbnN0IF9faW5qZWN0ZWRfZGlybmFtZV9fID0gXCIvd29ya3NwYWNlcy9taWRkbGV3YXJlXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy93b3Jrc3BhY2VzL21pZGRsZXdhcmUvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKG92ZXJyaWRlT3B0aW9ucykgPT4gKHtcbiAgLi4ub3ZlcnJpZGVPcHRpb25zLFxuICBjbGVhbjogdHJ1ZSxcbiAgZHRzOiB0cnVlLFxuICBmb3JtYXQ6IFsnY2pzJywgJ2VzbSddLFxuICBvdXREaXI6ICdkaXN0JyxcbiAgdHNjb25maWc6ICd0c2NvbmZpZy50c3VwLmpzb24nLFxufSkpXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWdOLFNBQVMsb0JBQW9CO0FBRTdPLElBQU8sc0JBQVEsYUFBYSxDQUFDLHFCQUFxQjtBQUFBLEVBQ2hELEdBQUc7QUFBQSxFQUNILE9BQU87QUFBQSxFQUNQLEtBQUs7QUFBQSxFQUNMLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxFQUNyQixRQUFRO0FBQUEsRUFDUixVQUFVO0FBQ1osRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K

--- a/tsup.config.bundled_mgduvd67ikf.mjs
+++ b/tsup.config.bundled_mgduvd67ikf.mjs
@@ -1,0 +1,14 @@
+// ../../tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig((overrideOptions) => ({
+  ...overrideOptions,
+  clean: true,
+  dts: true,
+  format: ["cjs", "esm"],
+  outDir: "dist",
+  tsconfig: "tsconfig.tsup.json"
+}));
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vdHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL3dvcmtzcGFjZXMvbWlkZGxld2FyZS90c3VwLmNvbmZpZy50c1wiO2NvbnN0IF9faW5qZWN0ZWRfZGlybmFtZV9fID0gXCIvd29ya3NwYWNlcy9taWRkbGV3YXJlXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy93b3Jrc3BhY2VzL21pZGRsZXdhcmUvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKG92ZXJyaWRlT3B0aW9ucykgPT4gKHtcbiAgLi4ub3ZlcnJpZGVPcHRpb25zLFxuICBjbGVhbjogdHJ1ZSxcbiAgZHRzOiB0cnVlLFxuICBmb3JtYXQ6IFsnY2pzJywgJ2VzbSddLFxuICBvdXREaXI6ICdkaXN0JyxcbiAgdHNjb25maWc6ICd0c2NvbmZpZy50c3VwLmpzb24nLFxufSkpXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWdOLFNBQVMsb0JBQW9CO0FBRTdPLElBQU8sc0JBQVEsYUFBYSxDQUFDLHFCQUFxQjtBQUFBLEVBQ2hELEdBQUc7QUFBQSxFQUNILE9BQU87QUFBQSxFQUNQLEtBQUs7QUFBQSxFQUNMLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxFQUNyQixRQUFRO0FBQUEsRUFDUixVQUFVO0FBQ1osRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K

--- a/tsup.config.bundled_myakcpnoca.mjs
+++ b/tsup.config.bundled_myakcpnoca.mjs
@@ -1,0 +1,14 @@
+// ../../tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig((overrideOptions) => ({
+  ...overrideOptions,
+  clean: true,
+  dts: true,
+  format: ["cjs", "esm"],
+  outDir: "dist",
+  tsconfig: "tsconfig.tsup.json"
+}));
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vdHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL3dvcmtzcGFjZXMvbWlkZGxld2FyZS90c3VwLmNvbmZpZy50c1wiO2NvbnN0IF9faW5qZWN0ZWRfZGlybmFtZV9fID0gXCIvd29ya3NwYWNlcy9taWRkbGV3YXJlXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy93b3Jrc3BhY2VzL21pZGRsZXdhcmUvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKG92ZXJyaWRlT3B0aW9ucykgPT4gKHtcbiAgLi4ub3ZlcnJpZGVPcHRpb25zLFxuICBjbGVhbjogdHJ1ZSxcbiAgZHRzOiB0cnVlLFxuICBmb3JtYXQ6IFsnY2pzJywgJ2VzbSddLFxuICBvdXREaXI6ICdkaXN0JyxcbiAgdHNjb25maWc6ICd0c2NvbmZpZy50c3VwLmpzb24nLFxufSkpXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWdOLFNBQVMsb0JBQW9CO0FBRTdPLElBQU8sc0JBQVEsYUFBYSxDQUFDLHFCQUFxQjtBQUFBLEVBQ2hELEdBQUc7QUFBQSxFQUNILE9BQU87QUFBQSxFQUNQLEtBQUs7QUFBQSxFQUNMLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxFQUNyQixRQUFRO0FBQUEsRUFDUixVQUFVO0FBQ1osRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K

--- a/tsup.config.bundled_ogce7lquek.mjs
+++ b/tsup.config.bundled_ogce7lquek.mjs
@@ -1,0 +1,14 @@
+// ../../tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig((overrideOptions) => ({
+  ...overrideOptions,
+  clean: true,
+  dts: true,
+  format: ["cjs", "esm"],
+  outDir: "dist",
+  tsconfig: "tsconfig.tsup.json"
+}));
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vdHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL3dvcmtzcGFjZXMvbWlkZGxld2FyZS90c3VwLmNvbmZpZy50c1wiO2NvbnN0IF9faW5qZWN0ZWRfZGlybmFtZV9fID0gXCIvd29ya3NwYWNlcy9taWRkbGV3YXJlXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy93b3Jrc3BhY2VzL21pZGRsZXdhcmUvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKG92ZXJyaWRlT3B0aW9ucykgPT4gKHtcbiAgLi4ub3ZlcnJpZGVPcHRpb25zLFxuICBjbGVhbjogdHJ1ZSxcbiAgZHRzOiB0cnVlLFxuICBmb3JtYXQ6IFsnY2pzJywgJ2VzbSddLFxuICBvdXREaXI6ICdkaXN0JyxcbiAgdHNjb25maWc6ICd0c2NvbmZpZy50c3VwLmpzb24nLFxufSkpXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWdOLFNBQVMsb0JBQW9CO0FBRTdPLElBQU8sc0JBQVEsYUFBYSxDQUFDLHFCQUFxQjtBQUFBLEVBQ2hELEdBQUc7QUFBQSxFQUNILE9BQU87QUFBQSxFQUNQLEtBQUs7QUFBQSxFQUNMLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxFQUNyQixRQUFRO0FBQUEsRUFDUixVQUFVO0FBQ1osRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K

--- a/tsup.config.bundled_oj63ewzkh7.mjs
+++ b/tsup.config.bundled_oj63ewzkh7.mjs
@@ -1,0 +1,14 @@
+// ../../tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig((overrideOptions) => ({
+  ...overrideOptions,
+  clean: true,
+  dts: true,
+  format: ["cjs", "esm"],
+  outDir: "dist",
+  tsconfig: "tsconfig.tsup.json"
+}));
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vdHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL3dvcmtzcGFjZXMvbWlkZGxld2FyZS90c3VwLmNvbmZpZy50c1wiO2NvbnN0IF9faW5qZWN0ZWRfZGlybmFtZV9fID0gXCIvd29ya3NwYWNlcy9taWRkbGV3YXJlXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy93b3Jrc3BhY2VzL21pZGRsZXdhcmUvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKG92ZXJyaWRlT3B0aW9ucykgPT4gKHtcbiAgLi4ub3ZlcnJpZGVPcHRpb25zLFxuICBjbGVhbjogdHJ1ZSxcbiAgZHRzOiB0cnVlLFxuICBmb3JtYXQ6IFsnY2pzJywgJ2VzbSddLFxuICBvdXREaXI6ICdkaXN0JyxcbiAgdHNjb25maWc6ICd0c2NvbmZpZy50c3VwLmpzb24nLFxufSkpXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWdOLFNBQVMsb0JBQW9CO0FBRTdPLElBQU8sc0JBQVEsYUFBYSxDQUFDLHFCQUFxQjtBQUFBLEVBQ2hELEdBQUc7QUFBQSxFQUNILE9BQU87QUFBQSxFQUNQLEtBQUs7QUFBQSxFQUNMLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxFQUNyQixRQUFRO0FBQUEsRUFDUixVQUFVO0FBQ1osRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K

--- a/tsup.config.bundled_q76ccv3x7p.mjs
+++ b/tsup.config.bundled_q76ccv3x7p.mjs
@@ -1,0 +1,14 @@
+// ../../tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig((overrideOptions) => ({
+  ...overrideOptions,
+  clean: true,
+  dts: true,
+  format: ["cjs", "esm"],
+  outDir: "dist",
+  tsconfig: "tsconfig.tsup.json"
+}));
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vdHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL3dvcmtzcGFjZXMvbWlkZGxld2FyZS90c3VwLmNvbmZpZy50c1wiO2NvbnN0IF9faW5qZWN0ZWRfZGlybmFtZV9fID0gXCIvd29ya3NwYWNlcy9taWRkbGV3YXJlXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy93b3Jrc3BhY2VzL21pZGRsZXdhcmUvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKG92ZXJyaWRlT3B0aW9ucykgPT4gKHtcbiAgLi4ub3ZlcnJpZGVPcHRpb25zLFxuICBjbGVhbjogdHJ1ZSxcbiAgZHRzOiB0cnVlLFxuICBmb3JtYXQ6IFsnY2pzJywgJ2VzbSddLFxuICBvdXREaXI6ICdkaXN0JyxcbiAgdHNjb25maWc6ICd0c2NvbmZpZy50c3VwLmpzb24nLFxufSkpXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWdOLFNBQVMsb0JBQW9CO0FBRTdPLElBQU8sc0JBQVEsYUFBYSxDQUFDLHFCQUFxQjtBQUFBLEVBQ2hELEdBQUc7QUFBQSxFQUNILE9BQU87QUFBQSxFQUNQLEtBQUs7QUFBQSxFQUNMLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxFQUNyQixRQUFRO0FBQUEsRUFDUixVQUFVO0FBQ1osRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K

--- a/tsup.config.bundled_u9jwmccnal8.mjs
+++ b/tsup.config.bundled_u9jwmccnal8.mjs
@@ -1,0 +1,14 @@
+// ../../tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig((overrideOptions) => ({
+  ...overrideOptions,
+  clean: true,
+  dts: true,
+  format: ["cjs", "esm"],
+  outDir: "dist",
+  tsconfig: "tsconfig.tsup.json"
+}));
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vdHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL3dvcmtzcGFjZXMvbWlkZGxld2FyZS90c3VwLmNvbmZpZy50c1wiO2NvbnN0IF9faW5qZWN0ZWRfZGlybmFtZV9fID0gXCIvd29ya3NwYWNlcy9taWRkbGV3YXJlXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy93b3Jrc3BhY2VzL21pZGRsZXdhcmUvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKG92ZXJyaWRlT3B0aW9ucykgPT4gKHtcbiAgLi4ub3ZlcnJpZGVPcHRpb25zLFxuICBjbGVhbjogdHJ1ZSxcbiAgZHRzOiB0cnVlLFxuICBmb3JtYXQ6IFsnY2pzJywgJ2VzbSddLFxuICBvdXREaXI6ICdkaXN0JyxcbiAgdHNjb25maWc6ICd0c2NvbmZpZy50c3VwLmpzb24nLFxufSkpXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWdOLFNBQVMsb0JBQW9CO0FBRTdPLElBQU8sc0JBQVEsYUFBYSxDQUFDLHFCQUFxQjtBQUFBLEVBQ2hELEdBQUc7QUFBQSxFQUNILE9BQU87QUFBQSxFQUNQLEtBQUs7QUFBQSxFQUNMLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxFQUNyQixRQUFRO0FBQUEsRUFDUixVQUFVO0FBQ1osRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K

--- a/tsup.config.bundled_uuvn8e3up6.mjs
+++ b/tsup.config.bundled_uuvn8e3up6.mjs
@@ -1,0 +1,14 @@
+// ../../tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig((overrideOptions) => ({
+  ...overrideOptions,
+  clean: true,
+  dts: true,
+  format: ["cjs", "esm"],
+  outDir: "dist",
+  tsconfig: "tsconfig.tsup.json"
+}));
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vdHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL3dvcmtzcGFjZXMvbWlkZGxld2FyZS90c3VwLmNvbmZpZy50c1wiO2NvbnN0IF9faW5qZWN0ZWRfZGlybmFtZV9fID0gXCIvd29ya3NwYWNlcy9taWRkbGV3YXJlXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy93b3Jrc3BhY2VzL21pZGRsZXdhcmUvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKG92ZXJyaWRlT3B0aW9ucykgPT4gKHtcbiAgLi4ub3ZlcnJpZGVPcHRpb25zLFxuICBjbGVhbjogdHJ1ZSxcbiAgZHRzOiB0cnVlLFxuICBmb3JtYXQ6IFsnY2pzJywgJ2VzbSddLFxuICBvdXREaXI6ICdkaXN0JyxcbiAgdHNjb25maWc6ICd0c2NvbmZpZy50c3VwLmpzb24nLFxufSkpXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWdOLFNBQVMsb0JBQW9CO0FBRTdPLElBQU8sc0JBQVEsYUFBYSxDQUFDLHFCQUFxQjtBQUFBLEVBQ2hELEdBQUc7QUFBQSxFQUNILE9BQU87QUFBQSxFQUNQLEtBQUs7QUFBQSxFQUNMLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxFQUNyQixRQUFRO0FBQUEsRUFDUixVQUFVO0FBQ1osRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K

--- a/tsup.config.bundled_v6g8cnjw28n.mjs
+++ b/tsup.config.bundled_v6g8cnjw28n.mjs
@@ -1,0 +1,14 @@
+// ../../tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig((overrideOptions) => ({
+  ...overrideOptions,
+  clean: true,
+  dts: true,
+  format: ["cjs", "esm"],
+  outDir: "dist",
+  tsconfig: "tsconfig.tsup.json"
+}));
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vdHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL3dvcmtzcGFjZXMvbWlkZGxld2FyZS90c3VwLmNvbmZpZy50c1wiO2NvbnN0IF9faW5qZWN0ZWRfZGlybmFtZV9fID0gXCIvd29ya3NwYWNlcy9taWRkbGV3YXJlXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy93b3Jrc3BhY2VzL21pZGRsZXdhcmUvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKG92ZXJyaWRlT3B0aW9ucykgPT4gKHtcbiAgLi4ub3ZlcnJpZGVPcHRpb25zLFxuICBjbGVhbjogdHJ1ZSxcbiAgZHRzOiB0cnVlLFxuICBmb3JtYXQ6IFsnY2pzJywgJ2VzbSddLFxuICBvdXREaXI6ICdkaXN0JyxcbiAgdHNjb25maWc6ICd0c2NvbmZpZy50c3VwLmpzb24nLFxufSkpXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWdOLFNBQVMsb0JBQW9CO0FBRTdPLElBQU8sc0JBQVEsYUFBYSxDQUFDLHFCQUFxQjtBQUFBLEVBQ2hELEdBQUc7QUFBQSxFQUNILE9BQU87QUFBQSxFQUNQLEtBQUs7QUFBQSxFQUNMLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxFQUNyQixRQUFRO0FBQUEsRUFDUixVQUFVO0FBQ1osRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K

--- a/tsup.config.bundled_w5wy0wclbg.mjs
+++ b/tsup.config.bundled_w5wy0wclbg.mjs
@@ -1,0 +1,14 @@
+// ../../tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig((overrideOptions) => ({
+  ...overrideOptions,
+  clean: true,
+  dts: true,
+  format: ["cjs", "esm"],
+  outDir: "dist",
+  tsconfig: "tsconfig.tsup.json"
+}));
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vdHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL3dvcmtzcGFjZXMvbWlkZGxld2FyZS90c3VwLmNvbmZpZy50c1wiO2NvbnN0IF9faW5qZWN0ZWRfZGlybmFtZV9fID0gXCIvd29ya3NwYWNlcy9taWRkbGV3YXJlXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy93b3Jrc3BhY2VzL21pZGRsZXdhcmUvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKG92ZXJyaWRlT3B0aW9ucykgPT4gKHtcbiAgLi4ub3ZlcnJpZGVPcHRpb25zLFxuICBjbGVhbjogdHJ1ZSxcbiAgZHRzOiB0cnVlLFxuICBmb3JtYXQ6IFsnY2pzJywgJ2VzbSddLFxuICBvdXREaXI6ICdkaXN0JyxcbiAgdHNjb25maWc6ICd0c2NvbmZpZy50c3VwLmpzb24nLFxufSkpXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWdOLFNBQVMsb0JBQW9CO0FBRTdPLElBQU8sc0JBQVEsYUFBYSxDQUFDLHFCQUFxQjtBQUFBLEVBQ2hELEdBQUc7QUFBQSxFQUNILE9BQU87QUFBQSxFQUNQLEtBQUs7QUFBQSxFQUNMLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxFQUNyQixRQUFRO0FBQUEsRUFDUixVQUFVO0FBQ1osRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K

--- a/tsup.config.bundled_whnwm5en73r.mjs
+++ b/tsup.config.bundled_whnwm5en73r.mjs
@@ -1,0 +1,14 @@
+// ../../tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig((overrideOptions) => ({
+  ...overrideOptions,
+  clean: true,
+  dts: true,
+  format: ["cjs", "esm"],
+  outDir: "dist",
+  tsconfig: "tsconfig.tsup.json"
+}));
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vdHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL3dvcmtzcGFjZXMvbWlkZGxld2FyZS90c3VwLmNvbmZpZy50c1wiO2NvbnN0IF9faW5qZWN0ZWRfZGlybmFtZV9fID0gXCIvd29ya3NwYWNlcy9taWRkbGV3YXJlXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy93b3Jrc3BhY2VzL21pZGRsZXdhcmUvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKG92ZXJyaWRlT3B0aW9ucykgPT4gKHtcbiAgLi4ub3ZlcnJpZGVPcHRpb25zLFxuICBjbGVhbjogdHJ1ZSxcbiAgZHRzOiB0cnVlLFxuICBmb3JtYXQ6IFsnY2pzJywgJ2VzbSddLFxuICBvdXREaXI6ICdkaXN0JyxcbiAgdHNjb25maWc6ICd0c2NvbmZpZy50c3VwLmpzb24nLFxufSkpXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWdOLFNBQVMsb0JBQW9CO0FBRTdPLElBQU8sc0JBQVEsYUFBYSxDQUFDLHFCQUFxQjtBQUFBLEVBQ2hELEdBQUc7QUFBQSxFQUNILE9BQU87QUFBQSxFQUNQLEtBQUs7QUFBQSxFQUNMLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxFQUNyQixRQUFRO0FBQUEsRUFDUixVQUFVO0FBQ1osRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K

--- a/tsup.config.bundled_xsbuy99x8h.mjs
+++ b/tsup.config.bundled_xsbuy99x8h.mjs
@@ -1,0 +1,14 @@
+// ../../tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig((overrideOptions) => ({
+  ...overrideOptions,
+  clean: true,
+  dts: true,
+  format: ["cjs", "esm"],
+  outDir: "dist",
+  tsconfig: "tsconfig.tsup.json"
+}));
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vdHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL3dvcmtzcGFjZXMvbWlkZGxld2FyZS90c3VwLmNvbmZpZy50c1wiO2NvbnN0IF9faW5qZWN0ZWRfZGlybmFtZV9fID0gXCIvd29ya3NwYWNlcy9taWRkbGV3YXJlXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy93b3Jrc3BhY2VzL21pZGRsZXdhcmUvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKG92ZXJyaWRlT3B0aW9ucykgPT4gKHtcbiAgLi4ub3ZlcnJpZGVPcHRpb25zLFxuICBjbGVhbjogdHJ1ZSxcbiAgZHRzOiB0cnVlLFxuICBmb3JtYXQ6IFsnY2pzJywgJ2VzbSddLFxuICBvdXREaXI6ICdkaXN0JyxcbiAgdHNjb25maWc6ICd0c2NvbmZpZy50c3VwLmpzb24nLFxufSkpXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWdOLFNBQVMsb0JBQW9CO0FBRTdPLElBQU8sc0JBQVEsYUFBYSxDQUFDLHFCQUFxQjtBQUFBLEVBQ2hELEdBQUc7QUFBQSxFQUNILE9BQU87QUFBQSxFQUNQLEtBQUs7QUFBQSxFQUNMLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxFQUNyQixRQUFRO0FBQUEsRUFDUixVQUFVO0FBQ1osRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K

--- a/yarn.lock
+++ b/yarn.lock
@@ -1946,6 +1946,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@hono/datadog@workspace:packages/datadog":
+  version: 0.0.0-use.local
+  resolution: "@hono/datadog@workspace:packages/datadog"
+  dependencies:
+    "@arethetypeswrong/cli": "npm:^0.17.4"
+    publint: "npm:^0.3.9"
+    tsup: "npm:^8.4.0"
+    typescript: "npm:^5.8.2"
+    vitest: "npm:^3.0.8"
+  peerDependencies:
+    dd-trace: ^1.0.0
+    hono: ">=3.9.0"
+  languageName: unknown
+  linkType: soft
+
 "@hono/effect-validator@workspace:packages/effect-validator":
   version: 0.0.0-use.local
   resolution: "@hono/effect-validator@workspace:packages/effect-validator"


### PR DESCRIPTION
Add Datadog middleware package for Hono.

* **Add Datadog package files**
  - Add `packages/datadog/package.json` with necessary configurations and dependencies.
  - Add `packages/datadog/README.md` with usage instructions and examples.
  - Add `packages/datadog/src/index.ts` to create and export the Datadog middleware function.
  - Add `packages/datadog/src/index.test.ts` to write tests for the Datadog middleware.
  - Add `packages/datadog/tsconfig.json`, `tsconfig.build.json`, and `tsconfig.spec.json` for TypeScript configurations.
  - Add `packages/datadog/vitest.config.ts` for Vitest configuration.

* **Modify root package.json**
  - Add `packages/datadog` to the workspaces.

* **Add .devcontainer configuration**
  - Add `.devcontainer/devcontainer.json` with build tasks.

* **Update yarn.lock**
  - Add dependencies for the new Datadog package.

* **Add tsup configuration files**
  - Add multiple `tsup.config.bundled_*.mjs` files for bundling configurations.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/roharon/middleware/pull/1?shareId=32536b7d-9db4-4106-bb06-2e822900c1be).